### PR TITLE
feat: Support a notation for unowned files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,6 @@ inputs:
     description: Whether to ignore the default `*` files
     default: "false"
     required: false
-  
   files:
     description: The files to check
     required: false

--- a/action.yml
+++ b/action.yml
@@ -12,14 +12,18 @@ inputs:
     required: false
   include-gitignore:
     description: Whether to include files in .gitignore
-    default: 'true'
+    default: "true"
     required: false
   ignore-default:
     description: Whether to ignore the default `*` files
-    default: 'false'
+    default: "false"
     required: false
   files:
     description: The files to check
+    required: false
+  parse-unowned-files:
+    description: Interpret lines starting with '#?' as unowned files that do not need to be covered
+    default: "true"
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Whether to ignore the default `*` files
     default: "false"
     required: false
+  ignore-git:
+    description: Whether to ignore the .git directory
+    default: "true"
+    required: false
   files:
     description: The files to check
     required: false

--- a/action.yml
+++ b/action.yml
@@ -14,14 +14,15 @@ inputs:
     description: Whether to include files in .gitignore
     default: "true"
     required: false
+  include-git:
+    description: Whether to include files in the .git directory
+    default: "false"
+    required: false
   ignore-default:
     description: Whether to ignore the default `*` files
     default: "false"
     required: false
-  ignore-git:
-    description: Whether to ignore the .git directory
-    default: "true"
-    required: false
+  
   files:
     description: The files to check
     required: false

--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     required: false
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -12020,7 +12020,7 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     const addIgnoresToPatterns = (patterns) => {
         let result = patterns;
         if (!input.includeGit) {
-            result += "\n.git";
+            result += "\n!.git";
         }
         return result;
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -12053,16 +12053,16 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let codeownersBufferFiles = codeownersBuffer
         .split("\n")
         .map((line) => line.split(" ")[0]);
-    codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
     codeownersBufferFiles = codeownersBufferFiles.map((file) => file.replace(/^\//, ""));
-    if (input.ignoreDefault === true) {
-        codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
-    }
     const unownedFilesPatterns = input.parseUnownedFiles
         ? codeownersBufferFiles
             .filter((file) => file.startsWith("#?"))
             .map((file) => file.replace(/^#\?/, ""))
         : [];
+    codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
+    if (input.ignoreDefault === true) {
+        codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
+    }
     const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"));
     let codeownersFiles = yield codeownersGlob.glob();
     core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -12059,6 +12059,7 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
             .filter((file) => file.startsWith("#?"))
             .map((file) => file.replace(/^#\?/, ""))
         : [];
+    console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
     codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
     if (input.ignoreDefault === true) {
         codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");

--- a/dist/index.js
+++ b/dist/index.js
@@ -12062,9 +12062,8 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
         ? codeownersBuffer
             .split("\n")
             .filter((file) => file.startsWith("#?"))
-            .map((file) => file.replace(/^#\?/, ""))
+            .map((file) => file.replace(/^#\?\s*/, ""))
         : [];
-    console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
     const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"));
     let codeownersFiles = yield codeownersGlob.glob();
     core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -12027,10 +12027,14 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let allFiles = [];
     if (input.files) {
         allFiles = input.files.split(" ");
-        allFiles = yield (yield glob.create(addIgnoresToPatterns(allFiles.join("\n")))).glob();
+        allFiles = yield (yield glob.create(addIgnoresToPatterns(allFiles.join("\n")), {
+            matchDirectories: false,
+        })).glob();
     }
     else {
-        allFiles = yield (yield glob.create(addIgnoresToPatterns("*"))).glob();
+        allFiles = yield (yield glob.create(addIgnoresToPatterns("*"), {
+            matchDirectories: false,
+        })).glob();
     }
     core.startGroup(`All Files: ${allFiles.length}`);
     core.info(JSON.stringify(allFiles));
@@ -12064,7 +12068,9 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
             .filter((file) => file.startsWith("#?"))
             .map((file) => file.replace(/^#\?\s*/, ""))
         : [];
-    const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"));
+    const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"), {
+        matchDirectories: false,
+    });
     let codeownersFiles = yield codeownersGlob.glob();
     core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);
     core.info(JSON.stringify(codeownersFiles));
@@ -12077,14 +12083,18 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let gitIgnoreFiles = [];
     try {
         const gitIgnoreBuffer = (0, fs_1.readFileSync)(".gitignore", "utf8");
-        const gitIgnoreGlob = yield glob.create(gitIgnoreBuffer);
+        const gitIgnoreGlob = yield glob.create(gitIgnoreBuffer, {
+            matchDirectories: false,
+        });
         gitIgnoreFiles = yield gitIgnoreGlob.glob();
         core.info(`.gitignore Files: ${gitIgnoreFiles.length}`);
     }
     catch (error) {
         core.info("No .gitignore file found");
     }
-    const unownedFilesGlob = yield glob.create(unownedFilesPatterns.join("\n"));
+    const unownedFilesGlob = yield glob.create(unownedFilesPatterns.join("\n"), {
+        matchDirectories: false,
+    });
     const unownedFiles = yield unownedFilesGlob.glob();
     if (input.parseUnownedFiles) {
         core.info(`Unowned Files: ${unownedFiles.length}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -12054,16 +12054,17 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
         .split("\n")
         .map((line) => line.split(" ")[0]);
     codeownersBufferFiles = codeownersBufferFiles.map((file) => file.replace(/^\//, ""));
-    const unownedFilesPatterns = input.parseUnownedFiles
-        ? codeownersBufferFiles
-            .filter((file) => file.startsWith("#?"))
-            .map((file) => file.replace(/^#\?/, ""))
-        : [];
-    console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
     codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
     if (input.ignoreDefault === true) {
         codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
     }
+    const unownedFilesPatterns = input.parseUnownedFiles
+        ? codeownersBuffer
+            .split("\n")
+            .filter((file) => file.startsWith("#?"))
+            .map((file) => file.replace(/^#\?/, ""))
+        : [];
+    console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
     const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"));
     let codeownersFiles = yield codeownersGlob.glob();
     core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,10 +39,16 @@ export const runAction = async (
   if (input.files) {
     allFiles = input.files.split(" ");
     allFiles = await (
-      await glob.create(addIgnoresToPatterns(allFiles.join("\n")))
+      await glob.create(addIgnoresToPatterns(allFiles.join("\n")), {
+        matchDirectories: false,
+      })
     ).glob();
   } else {
-    allFiles = await (await glob.create(addIgnoresToPatterns("*"))).glob();
+    allFiles = await (
+      await glob.create(addIgnoresToPatterns("*"), {
+        matchDirectories: false,
+      })
+    ).glob();
   }
   core.startGroup(`All Files: ${allFiles.length}`);
   core.info(JSON.stringify(allFiles));
@@ -83,7 +89,9 @@ export const runAction = async (
         .map((file) => file.replace(/^#\?\s*/, ""))
     : [];
 
-  const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"));
+  const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"), {
+    matchDirectories: false,
+  });
   let codeownersFiles = await codeownersGlob.glob();
   core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);
   core.info(JSON.stringify(codeownersFiles));
@@ -97,14 +105,18 @@ export const runAction = async (
   let gitIgnoreFiles: string[] = [];
   try {
     const gitIgnoreBuffer = readFileSync(".gitignore", "utf8");
-    const gitIgnoreGlob = await glob.create(gitIgnoreBuffer);
+    const gitIgnoreGlob = await glob.create(gitIgnoreBuffer, {
+      matchDirectories: false,
+    });
     gitIgnoreFiles = await gitIgnoreGlob.glob();
     core.info(`.gitignore Files: ${gitIgnoreFiles.length}`);
   } catch (error) {
     core.info("No .gitignore file found");
   }
 
-  const unownedFilesGlob = await glob.create(unownedFilesPatterns.join("\n"));
+  const unownedFilesGlob = await glob.create(unownedFilesPatterns.join("\n"), {
+    matchDirectories: false,
+  });
   const unownedFiles: string[] = await unownedFilesGlob.glob();
   if (input.parseUnownedFiles) {
     core.info(`Unowned Files: ${unownedFiles.length}`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ interface Input {
   includeGitignore: boolean;
   ignoreDefault: boolean;
   parseUnownedFiles: boolean;
+  ignoreGit: boolean;
   files: string;
 }
 
@@ -17,6 +18,7 @@ export function getInputs(): Input {
   result.includeGitignore = core.getBooleanInput("include-gitignore");
   result.ignoreDefault = core.getBooleanInput("ignore-default");
   result.parseUnownedFiles = core.getBooleanInput("parse-unowned-files");
+  result.ignoreGit = core.getBooleanInput("ignore-git");
   result.files = core.getInput("files");
   return result;
 }
@@ -92,7 +94,7 @@ export const runAction = async (
 
   const unownedFilesGlob = await glob.create(unownedFilesPatterns.join("\n"));
   const unownedFiles: string[] = await unownedFilesGlob.glob();
-  if (unownedFiles.length > 0) {
+  if (input.parseUnownedFiles) {
     core.info(`Unowned Files: ${unownedFiles.length}`);
   }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,6 +7,7 @@ interface Input {
   token: string;
   "include-gitignore": boolean;
   "ignore-default": boolean;
+  "parse-unowned-files": boolean;
   files: string;
 }
 
@@ -15,6 +16,7 @@ export function getInputs(): Input {
   result.token = core.getInput("github-token");
   result["include-gitignore"] = core.getBooleanInput("include-gitignore");
   result["ignore-default"] = core.getBooleanInput("ignore-default");
+  result["parse-unowned-files"] = core.getBooleanInput("parse-unowned-files");
   result.files = core.getInput("files");
   return result;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -64,22 +64,22 @@ export const runAction = async (
   let codeownersBufferFiles = codeownersBuffer
     .split("\n")
     .map((line) => line.split(" ")[0]);
-  codeownersBufferFiles = codeownersBufferFiles.filter(
-    (file) => !file.startsWith("#")
-  );
   codeownersBufferFiles = codeownersBufferFiles.map((file) =>
     file.replace(/^\//, "")
+  );
+  const unownedFilesPatterns: string[] = input.parseUnownedFiles
+    ? codeownersBufferFiles
+        .filter((file) => file.startsWith("#?"))
+        .map((file) => file.replace(/^#\?/, ""))
+    : [];
+  codeownersBufferFiles = codeownersBufferFiles.filter(
+    (file) => !file.startsWith("#")
   );
   if (input.ignoreDefault === true) {
     codeownersBufferFiles = codeownersBufferFiles.filter(
       (file) => file !== "*"
     );
   }
-  const unownedFilesPatterns: string[] = input.parseUnownedFiles
-    ? codeownersBufferFiles
-        .filter((file) => file.startsWith("#?"))
-        .map((file) => file.replace(/^#\?/, ""))
-    : [];
 
   const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"));
   let codeownersFiles = await codeownersGlob.glob();

--- a/src/run.ts
+++ b/src/run.ts
@@ -30,7 +30,7 @@ export const runAction = async (
   const addIgnoresToPatterns = (patterns: string) => {
     let result = patterns;
     if (!input.includeGit) {
-      result += "\n.git";
+      result += "\n!.git";
     }
     return result;
   };

--- a/src/run.ts
+++ b/src/run.ts
@@ -72,6 +72,8 @@ export const runAction = async (
         .filter((file) => file.startsWith("#?"))
         .map((file) => file.replace(/^#\?/, ""))
     : [];
+  console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
+
   codeownersBufferFiles = codeownersBufferFiles.filter(
     (file) => !file.startsWith("#")
   );

--- a/src/run.ts
+++ b/src/run.ts
@@ -67,13 +67,6 @@ export const runAction = async (
   codeownersBufferFiles = codeownersBufferFiles.map((file) =>
     file.replace(/^\//, "")
   );
-  const unownedFilesPatterns: string[] = input.parseUnownedFiles
-    ? codeownersBufferFiles
-        .filter((file) => file.startsWith("#?"))
-        .map((file) => file.replace(/^#\?/, ""))
-    : [];
-  console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
-
   codeownersBufferFiles = codeownersBufferFiles.filter(
     (file) => !file.startsWith("#")
   );
@@ -82,6 +75,14 @@ export const runAction = async (
       (file) => file !== "*"
     );
   }
+
+  const unownedFilesPatterns: string[] = input.parseUnownedFiles
+    ? codeownersBuffer
+        .split("\n")
+        .filter((file) => file.startsWith("#?"))
+        .map((file) => file.replace(/^#\?/, ""))
+    : [];
+  console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
 
   const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"));
   let codeownersFiles = await codeownersGlob.glob();

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,18 +5,18 @@ import { readFileSync } from "fs";
 
 interface Input {
   token: string;
-  "include-gitignore": boolean;
-  "ignore-default": boolean;
-  "parse-unowned-files": boolean;
+  includeGitignore: boolean;
+  ignoreDefault: boolean;
+  parseUnownedFiles: boolean;
   files: string;
 }
 
 export function getInputs(): Input {
   const result = {} as Input;
   result.token = core.getInput("github-token");
-  result["include-gitignore"] = core.getBooleanInput("include-gitignore");
-  result["ignore-default"] = core.getBooleanInput("ignore-default");
-  result["parse-unowned-files"] = core.getBooleanInput("parse-unowned-files");
+  result.includeGitignore = core.getBooleanInput("include-gitignore");
+  result.ignoreDefault = core.getBooleanInput("ignore-default");
+  result.parseUnownedFiles = core.getBooleanInput("parse-unowned-files");
   result.files = core.getInput("files");
   return result;
 }
@@ -58,7 +58,7 @@ export const runAction = async (
   codeownersBufferFiles = codeownersBufferFiles.map((file) =>
     file.replace(/^\//, "")
   );
-  if (input["ignore-default"] === true) {
+  if (input.ignoreDefault === true) {
     codeownersBufferFiles = codeownersBufferFiles.filter(
       (file) => file !== "*"
     );
@@ -86,7 +86,7 @@ export const runAction = async (
 
   let filesCovered = codeownersFiles;
   let allFilesClean = allFiles;
-  if (input["include-gitignore"] === true) {
+  if (input.includeGitignore === true) {
     allFilesClean = allFiles.filter((file) => !gitIgnoreFiles.includes(file));
     filesCovered = filesCovered.filter(
       (file) => !gitIgnoreFiles.includes(file)

--- a/src/run.ts
+++ b/src/run.ts
@@ -134,9 +134,7 @@ export const runAction = async (
   }
 
   if (filesNotCovered.length > 0) {
-    core.setFailed(
-      "Files not covered by CODEOWNERS: \n" + filesNotCovered.join("\n")
-    );
+    core.setFailed(`${filesNotCovered.length} files not covered by CODEOWNERS`);
   }
 };
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -80,9 +80,8 @@ export const runAction = async (
     ? codeownersBuffer
         .split("\n")
         .filter((file) => file.startsWith("#?"))
-        .map((file) => file.replace(/^#\?/, ""))
+        .map((file) => file.replace(/^#\?\s*/, ""))
     : [];
-  console.log("(tmp) Unowned files patterns: ", unownedFilesPatterns);
 
   const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"));
   let codeownersFiles = await codeownersGlob.glob();


### PR DESCRIPTION
# Rationale

See https://linear.app/sibi/issue/WOPR-537/ignore-certain-infrastructure-files-when-checking-codeowners-coverage; some files aren't helpful to have a single CODEOWNER because multiple teams will be accessing them. Particularly applies to generated files like `pnpm-lock.yaml`.

# Considerations

Also excluded the `.git` directory from consideration; the dispatchable workflow was including it for some reason.

Don't consider directories; we only care about the files in them. (if a directory isn't owned, then it'll get caught as soon as a file gets added to it)

Refactored the inputs a bit to make their names more JS-friendly.

Don't duplicate "not covered" error messages; the final error will just give a count instead.