### PR TITLE
fix: Match behavior of actual CODEOWNERS files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12057,7 +12057,7 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let codeownersBufferFiles = codeownersBuffer
         .split("\n")
         .map((line) => line.split(" ")[0]);
-    codeownersBufferFiles = codeownersBufferFiles.map((file) => file.replace(/^\//, ""));
+    codeownersBufferFiles = codeownersBufferFiles.map((file) => codeownerPatternToGlob(file));
     codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
     if (input.ignoreDefault === true) {
         codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
@@ -12067,6 +12067,7 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
             .split("\n")
             .filter((file) => file.startsWith("#?"))
             .map((file) => file.replace(/^#\?\s*/, ""))
+            .map((file) => codeownerPatternToGlob(file))
         : [];
     const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"), {
         matchDirectories: false,
@@ -12129,6 +12130,14 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     }
 });
 exports.runAction = runAction;
+function codeownerPatternToGlob(pattern) {
+    if (pattern.startsWith("/")) {
+        return pattern.replace(/^\//, "");
+    }
+    else {
+        return "**/" + pattern;
+    }
+}
 const run = () => __awaiter(void 0, void 0, void 0, function* () {
     try {
         const input = getInputs();

--- a/dist/index.js
+++ b/dist/index.js
@@ -12057,11 +12057,15 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     let codeownersBufferFiles = codeownersBuffer
         .split("\n")
         .map((line) => line.split(" ")[0]);
-    codeownersBufferFiles = codeownersBufferFiles.map((file) => codeownerPatternToGlob(file));
     codeownersBufferFiles = codeownersBufferFiles.filter((file) => !file.startsWith("#"));
+    codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "");
     if (input.ignoreDefault === true) {
         codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "*");
     }
+    codeownersBufferFiles = codeownersBufferFiles.map((file) => codeownerPatternToGlob(file));
+    core.startGroup("CODEOWNERS Glob Patterns");
+    core.info(JSON.stringify(codeownersBufferFiles));
+    core.endGroup();
     const unownedFilesPatterns = input.parseUnownedFiles
         ? codeownersBuffer
             .split("\n")
@@ -12069,6 +12073,9 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
             .map((file) => file.replace(/^#\?\s*/, ""))
             .map((file) => codeownerPatternToGlob(file))
         : [];
+    core.startGroup(`Unowned Files Glob Patterns: ${unownedFilesPatterns.length}`);
+    core.info(JSON.stringify(unownedFilesPatterns));
+    core.endGroup();
     const codeownersGlob = yield glob.create(codeownersBufferFiles.join("\n"), {
         matchDirectories: false,
     });
@@ -12098,7 +12105,9 @@ const runAction = (_octokit, input) => __awaiter(void 0, void 0, void 0, functio
     });
     const unownedFiles = yield unownedFilesGlob.glob();
     if (input.parseUnownedFiles) {
-        core.info(`Unowned Files: ${unownedFiles.length}`);
+        core.startGroup("`Unowned Files: ${unownedFiles.length}`");
+        core.info(JSON.stringify(unownedFiles));
+        core.endGroup();
     }
     let filesCovered = codeownersFiles;
     let allFilesClean = allFiles;

--- a/src/run.ts
+++ b/src/run.ts
@@ -70,17 +70,22 @@ export const runAction = async (
   let codeownersBufferFiles = codeownersBuffer
     .split("\n")
     .map((line) => line.split(" ")[0]);
-  codeownersBufferFiles = codeownersBufferFiles.map((file) =>
-    codeownerPatternToGlob(file)
-  );
   codeownersBufferFiles = codeownersBufferFiles.filter(
     (file) => !file.startsWith("#")
   );
+  codeownersBufferFiles = codeownersBufferFiles.filter((file) => file !== "");
   if (input.ignoreDefault === true) {
     codeownersBufferFiles = codeownersBufferFiles.filter(
       (file) => file !== "*"
     );
   }
+  codeownersBufferFiles = codeownersBufferFiles.map((file) =>
+    codeownerPatternToGlob(file)
+  );
+
+  core.startGroup("CODEOWNERS Glob Patterns");
+  core.info(JSON.stringify(codeownersBufferFiles));
+  core.endGroup();
 
   const unownedFilesPatterns: string[] = input.parseUnownedFiles
     ? codeownersBuffer
@@ -89,6 +94,11 @@ export const runAction = async (
         .map((file) => file.replace(/^#\?\s*/, ""))
         .map((file) => codeownerPatternToGlob(file))
     : [];
+  core.startGroup(
+    `Unowned Files Glob Patterns: ${unownedFilesPatterns.length}`
+  );
+  core.info(JSON.stringify(unownedFilesPatterns));
+  core.endGroup();
 
   const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"), {
     matchDirectories: false,
@@ -120,7 +130,9 @@ export const runAction = async (
   });
   const unownedFiles: string[] = await unownedFilesGlob.glob();
   if (input.parseUnownedFiles) {
-    core.info(`Unowned Files: ${unownedFiles.length}`);
+    core.startGroup("`Unowned Files: ${unownedFiles.length}`");
+    core.info(JSON.stringify(unownedFiles));
+    core.endGroup();
   }
 
   let filesCovered = codeownersFiles;
@@ -165,6 +177,7 @@ export const runAction = async (
 };
 
 function codeownerPatternToGlob(pattern: string): string {
+  // TODO: document the differences between syntaxes
   if (pattern.startsWith("/")) {
     return pattern.replace(/^\//, "");
   } else {

--- a/src/run.ts
+++ b/src/run.ts
@@ -177,6 +177,16 @@ export const runAction = async (
 };
 
 function codeownerPatternToGlob(pattern: string): string {
+  // CODEOWNERS patterns are kind of like gitignore. By default
+  // they match in any directory, unless they start with `/`, in
+  // which case they start from the workspace root.
+  // Ex. `index.js` would match any `index.js` file anywhere in the project,
+  // but `/package.json` would specifically match the root `package.json` file
+  // and not any others.
+
+  // Glob patterns are relative to the workspace root by default,
+  // but a prefix of `**/` creates behavior similar to no prefix in CODEOWNERS.
+
   // TODO: document the differences between syntaxes
   if (pattern.startsWith("/")) {
     return pattern.replace(/^\//, "");

--- a/src/run.ts
+++ b/src/run.ts
@@ -71,7 +71,7 @@ export const runAction = async (
     .split("\n")
     .map((line) => line.split(" ")[0]);
   codeownersBufferFiles = codeownersBufferFiles.map((file) =>
-    file.replace(/^\//, "")
+    codeownerPatternToGlob(file)
   );
   codeownersBufferFiles = codeownersBufferFiles.filter(
     (file) => !file.startsWith("#")
@@ -87,6 +87,7 @@ export const runAction = async (
         .split("\n")
         .filter((file) => file.startsWith("#?"))
         .map((file) => file.replace(/^#\?\s*/, ""))
+        .map((file) => codeownerPatternToGlob(file))
     : [];
 
   const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"), {
@@ -162,6 +163,14 @@ export const runAction = async (
     core.setFailed(`${filesNotCovered.length} files not covered by CODEOWNERS`);
   }
 };
+
+function codeownerPatternToGlob(pattern: string): string {
+  if (pattern.startsWith("/")) {
+    return pattern.replace(/^\//, "");
+  } else {
+    return "**/" + pattern;
+  }
+}
 
 const run = async (): Promise<void> => {
   try {


### PR DESCRIPTION
# Rationale

I noticed while adding CODEOWNERS enforcement to Biggie that the existing behavior parsed CODEOWNERS patterns as globs, but actually GitHub will parse them as something much more like `gitignore` syntax.

## Considerations

This project doesn't have usable automated tests, but I verified my changes by copying the `dist/index.js` file into Biggie and temporarily running the action that way.

RZA pulls this action from the `v1` branch, so the changes will take affect as soon as this PR is merged.