### PR TITLE
use debug logs

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -50,9 +50,12 @@ export const runAction = async (
       })
     ).glob();
   }
-  core.startGroup(`All Files: ${allFiles.length}`);
-  core.info(JSON.stringify(allFiles));
-  core.endGroup();
+
+  if (core.isDebug()) {
+    core.startGroup(`All Files: ${allFiles.length}`);
+    core.debug(JSON.stringify(allFiles));
+    core.endGroup();
+  }
 
   let codeownersBuffer: string;
   try {
@@ -64,9 +67,13 @@ export const runAction = async (
       throw new Error("No CODEOWNERS file found");
     }
   }
-  core.startGroup("CODEOWNERS File");
-  core.info(codeownersBuffer);
-  core.endGroup();
+
+  if (core.isDebug()) {
+    core.startGroup("CODEOWNERS File");
+    core.debug(codeownersBuffer);
+    core.endGroup();
+  }
+
   let codeownersBufferFiles = codeownersBuffer
     .split("\n")
     .map((line) => line.split(" ")[0]);
@@ -83,9 +90,11 @@ export const runAction = async (
     codeownerPatternToGlob(file)
   );
 
-  core.startGroup("CODEOWNERS Glob Patterns");
-  core.info(JSON.stringify(codeownersBufferFiles));
-  core.endGroup();
+  if (core.isDebug()) {
+    core.startGroup("CODEOWNERS Glob Patterns");
+    core.debug(JSON.stringify(codeownersBufferFiles));
+    core.endGroup();
+  }
 
   const unownedFilesPatterns: string[] = input.parseUnownedFiles
     ? codeownersBuffer
@@ -94,24 +103,34 @@ export const runAction = async (
         .map((file) => file.replace(/^#\?\s*/, ""))
         .map((file) => codeownerPatternToGlob(file))
     : [];
-  core.startGroup(
-    `Unowned Files Glob Patterns: ${unownedFilesPatterns.length}`
-  );
-  core.info(JSON.stringify(unownedFilesPatterns));
-  core.endGroup();
+
+  if (core.isDebug()) {
+    core.startGroup(
+      `Unowned Files Glob Patterns: ${unownedFilesPatterns.length}`
+    );
+    core.debug(JSON.stringify(unownedFilesPatterns));
+    core.endGroup();
+  }
 
   const codeownersGlob = await glob.create(codeownersBufferFiles.join("\n"), {
     matchDirectories: false,
   });
   let codeownersFiles = await codeownersGlob.glob();
-  core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);
-  core.info(JSON.stringify(codeownersFiles));
-  core.endGroup();
+
+  if (core.isDebug()) {
+    core.startGroup(`CODEOWNERS Files: ${codeownersFiles.length}`);
+    core.debug(JSON.stringify(codeownersFiles));
+    core.endGroup();
+  }
+
   codeownersFiles = codeownersFiles.filter((file) => allFiles.includes(file));
-  core.info(`CODEOWNER Files in All Files: ${codeownersFiles.length}`);
-  core.startGroup("CODEOWNERS");
-  core.info(JSON.stringify(codeownersFiles));
-  core.endGroup();
+
+  if (core.isDebug()) {
+    core.debug(`CODEOWNER Files in All Files: ${codeownersFiles.length}`);
+    core.startGroup("CODEOWNERS");
+    core.debug(JSON.stringify(codeownersFiles));
+    core.endGroup();
+  }
 
   let gitIgnoreFiles: string[] = [];
   try {
@@ -120,9 +139,9 @@ export const runAction = async (
       matchDirectories: false,
     });
     gitIgnoreFiles = await gitIgnoreGlob.glob();
-    core.info(`.gitignore Files: ${gitIgnoreFiles.length}`);
+    core.debug(`.gitignore Files: ${gitIgnoreFiles.length}`);
   } catch (error) {
-    core.info("No .gitignore file found");
+    core.debug("No .gitignore file found");
   }
 
   const unownedFilesGlob = await glob.create(unownedFilesPatterns.join("\n"), {


### PR DESCRIPTION
Hey, we have a very large repository and each folder (or file) has a code owner.
This causes the action to generate a lot of logs, so that the important "File not covered by CODEOWNERS: ..." logs are no longer displayed in the overview.
GitHub warning from the action: `This step has been truncated due to its large size. View the raw logs from the menu once the workflow run has completed.`
<img width="1481" height="255" alt="image" src="https://github.com/user-attachments/assets/f6654d11-711b-4aef-ab83-6fa41d8d7d33" />


You can still view the logs via the “raw logs,” but it would be nicer to see them directly in the first overview.
What do you think about setting all other logs to the debug log level?

Tested from my develop branch:
<img width="1450" height="182" alt="image" src="https://github.com/user-attachments/assets/093df48c-ca56-4c08-a9d5-121343dddc25" />

Note: This PR does not include the build `dist/index.js`